### PR TITLE
fix dependabot warnings

### DIFF
--- a/robot/ros_ws/README.md
+++ b/robot/ros_ws/README.md
@@ -10,6 +10,7 @@ Code ROS de l'herminebot
   - [Command line usage](#command-line-usage)
 - [ROS dependencies](#ros-dependencies)
 - [Build dependencies](#build-dependencies)
+- [Python dependencies](#python-dependencies)
 
 # Versions
 

--- a/robot/ros_ws/requirements.txt
+++ b/robot/ros_ws/requirements.txt
@@ -1,5 +1,5 @@
 launch-ros~=0.19.8
 pytest~=8.3.4
 launch~=1.0.7
-setuptools~=59.6.0
+setuptools~=75.8.0
 rclpy~=3.3.15


### PR DESCRIPTION
1) A vulnerability in the package_index module of pypa/setuptools versions up to 69.1.1 allows for remote code execution via its download functions. These functions, which are used to download packages from URLs provided by users or retrieved from package index servers, are susceptible to code injection. If these functions are exposed to user-controlled inputs, such as package URLs, they can execute arbitrary commands on the system. The issue is fixed in version 70.0.

2) Python Packaging Authority (PyPA)'s setuptools is a library designed to facilitate packaging Python projects. Setuptools version 65.5.0 and earlier could allow remote attackers to cause a denial of service by fetching malicious HTML from a PyPI package or custom PackageIndex page due to a vulnerable Regular Expression in package_index. This has been patched in version 65.5.1.