### PR TITLE
fix omnidrive bt plugin can't load

### DIFF
--- a/robot/ros_ws/src/herminebot_behaviors/README.md
+++ b/robot/ros_ws/src/herminebot_behaviors/README.md
@@ -60,7 +60,7 @@ This plugin allows to modify the elements mask map. The mask can be modified wit
 />
 ```
 
-## MoveElevators
+## OmniDrive
 
 This plugin allows to move the robot in any direction.
 

--- a/robot/ros_ws/src/herminebot_behaviors/behavior_trees/omni_preemption.xml
+++ b/robot/ros_ws/src/herminebot_behaviors/behavior_trees/omni_preemption.xml
@@ -3,13 +3,13 @@
         <RecoveryNode number_of_retries="1" name="PreemptionRecovery">
             <SequenceWithMemory name="PreemptionSequence">
                 <MoveElevators time_allowance="2.5" elevators_ids="0" elevators_poses="0.02"/>
-                <DriveOnHeading dist_to_travel="0.1" speed="0.1" time_allowance="5.0"/>
+                <OmniDrive target_x="0.1" target_y="0.0" speed="0.1" time_allowance="5.0"/>
                 <MoveElevators time_allowance="2.5" elevators_ids="0" elevators_poses="0.1"/>
                 <ManageMap points_objects_to_remove="[[0.15, 0.0]]" is_robot_relative="true"/>
-                <DriveOnHeading dist_to_travel="-0.1" speed="-0.1" time_allowance="5.0"/>
+                <OmniDrive target_x="-0.1" target_y="0.0" speed="0.1" time_allowance="5.0"/>
                 <!-- example usage, to be modified
-                <ManageMap
-                    new_objects="[[-0.2, -0.2], [-0.2,0.2], [-0.1,0.2], [-0.1,-0.2]]"
+                <ManageMap 
+                    new_objects="[[-0.2, -0.2], [-0.2,0.2], [-0.1,0.2], [-0.1,-0.2]]" 
                     is_robot_relative="true"
                 /> -->
             </SequenceWithMemory>

--- a/robot/ros_ws/src/herminebot_navigation/params/nav2_params_herminebot_diff.yaml
+++ b/robot/ros_ws/src/herminebot_navigation/params/nav2_params_herminebot_diff.yaml
@@ -62,6 +62,7 @@ bt_navigator:
     default_server_timeout: 20
     default_nav_to_pose_bt_xml: $(find-pkg-share herminebot_navigation)/behavior_tree/navigate_to_pose_and_recovery.xml
     default_nav_through_poses_bt_xml: $(find-pkg-share herminebot_navigation)/behavior_tree/navigate_through_poses_and_recovery.xml
+    default_preemption_bt_xml: $(find-pkg-share herminebot_behaviors)/behavior_trees/preemption.xml
     navigators: ["navigate_to_pose", "navigate_through_poses", "preempt"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator::NavigateToPoseNavigator"

--- a/robot/ros_ws/src/herminebot_navigation/params/nav2_params_herminebot_omni.erb
+++ b/robot/ros_ws/src/herminebot_navigation/params/nav2_params_herminebot_omni.erb
@@ -70,6 +70,7 @@ bt_navigator:
     default_server_timeout: 20
     default_nav_to_pose_bt_xml: $(find-pkg-share herminebot_navigation)/behavior_tree/navigate_to_pose_and_recovery.xml
     default_nav_through_poses_bt_xml: $(find-pkg-share herminebot_navigation)/behavior_tree/navigate_through_poses_and_recovery.xml
+    default_preemption_bt_xml: $(find-pkg-share herminebot_behaviors)/behavior_trees/omni_preemption.xml
     navigators: ["navigate_to_pose", "navigate_through_poses", "preempt"]
     navigate_to_pose:
       plugin: "nav2_bt_navigator::NavigateToPoseNavigator"


### PR DESCRIPTION
Problem:
When the environment variable HERMINEBOT_MODEL value is 'diff', the plugin cannot be loaded

Cause:
The plugin was not added in the bt_navigator in the diff param file