### PR TITLE
fix initial pose fail with triangulation

### DIFF
--- a/robot/ros_ws/src/herminebot_navigation/include/herminebot_navigation/robot_triangulation.hpp
+++ b/robot/ros_ws/src/herminebot_navigation/include/herminebot_navigation/robot_triangulation.hpp
@@ -5,6 +5,7 @@
 #include "sensor_msgs/msg/laser_scan.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "geometry_msgs/msg/pose_array.hpp"
+#include "geometry_msgs/msg/pose2_d.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include "tf2_ros/transform_listener.h"
@@ -131,6 +132,9 @@ protected:
     rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr parameters_handler_;
     std::array<double, 36> triangulation_covariance_;
     rclcpp::Subscription<hrc_interfaces::msg::Restart>::SharedPtr restart_sub_;
+    geometry_msgs::msg::Pose2D initial_pose_;
+    bool initial_pose_received_;
+    nav_msgs::msg::Odometry initial_pose_odom_msg_;
 
     static constexpr double triangulation_covariance_default_[36] = {
         //  x,  y,  z, roll, pitch, yaw

--- a/robot/ros_ws/src/hrc_utils/include/hrc_utils/utils.hpp
+++ b/robot/ros_ws/src/hrc_utils/include/hrc_utils/utils.hpp
@@ -20,6 +20,15 @@ void robotToMap(
     const geometry_msgs::msg::Point32& robot_point,
     geometry_msgs::msg::Point32& map_point);
 
+/** Check if two floats are equal
+ * @param a First float
+ * @param b Second float
+ * @param epsilon Error margin
+ * @return True if the two floats are equal
+ */
+bool floatEqual(const float a, const float b, const float epsilon = 1e-5f);
+bool floatEqual(const double a, const double b, const double epsilon = 1e-5);
+
 } // namespace hrc_utils
 
 #endif // HRC_UTILS__UTILS_HPP

--- a/robot/ros_ws/src/hrc_utils/src/utils.cpp
+++ b/robot/ros_ws/src/hrc_utils/src/utils.cpp
@@ -12,4 +12,14 @@ void robotToMap(
     map_point.y = robot_point.x * sin(robot_pose.theta) + robot_point.y * cos(robot_pose.theta) + robot_pose.y;
 }
 
+bool floatEqual(const float a, const float b, const float epsilon)
+{
+    return fabs(a - b) < epsilon;
+}
+
+bool floatEqual(const double a, const double b, const double epsilon)
+{
+    return fabs(a - b) < epsilon;
+}
+
 } // namespace hrc_utils

--- a/robot/ros_ws/src/hrc_utils/test/test_utils.cpp
+++ b/robot/ros_ws/src/hrc_utils/test/test_utils.cpp
@@ -37,3 +37,14 @@ TEST(TestUtils, RobotToMap)
     ASSERT_NEAR(map_point.x, -0.5, HRC_UTILS__TESTING_FLOAT_ASSERTION_PRECISION);
     ASSERT_NEAR(map_point.y, 1.5, HRC_UTILS__TESTING_FLOAT_ASSERTION_PRECISION);
 }
+
+TEST(TestUtils, FloatComparison)
+{
+    // Double
+    ASSERT_TRUE(hrc_utils::floatEqual(1.0, 1.0, HRC_UTILS__TESTING_FLOAT_ASSERTION_PRECISION));
+    ASSERT_FALSE(hrc_utils::floatEqual(1.0, 1.1, HRC_UTILS__TESTING_FLOAT_ASSERTION_PRECISION));
+
+    // Float
+    ASSERT_TRUE(hrc_utils::floatEqual(1.0f, 1.0f, (float) HRC_UTILS__TESTING_FLOAT_ASSERTION_PRECISION));
+    ASSERT_FALSE(hrc_utils::floatEqual(1.0f, 1.1f, (float) HRC_UTILS__TESTING_FLOAT_ASSERTION_PRECISION));
+}


### PR DESCRIPTION
When setting an initial pose, it is not taken into account correcty. This is because the previous pose is taken into account so the new pose is filtered. To fix this, the weight of the initial pose is increased and is sent while the robot pose is not good